### PR TITLE
fix: only download bestaudio if user just wants any audio-format (or …

### DIFF
--- a/ydl_server/ydlhandler.py
+++ b/ydl_server/ydlhandler.py
@@ -83,8 +83,10 @@ def get_ydl_options(request_options):
 
     if requested_format in ['aac', 'flac', 'mp3', 'm4a', 'opus', 'vorbis', 'wav']:
         request_vars['YDL_EXTRACT_AUDIO_FORMAT'] = requested_format
+        request_vars['YDL_FORMAT'] = 'bestaudio'
     elif requested_format == 'bestaudio':
         request_vars['YDL_EXTRACT_AUDIO_FORMAT'] = 'best'
+        request_vars['YDL_FORMAT'] = 'bestaudio'
     elif requested_format in ['mp4', 'flv', 'webm', 'ogg', 'mkv', 'avi']:
         request_vars['YDL_RECODE_VIDEO_FORMAT'] = requested_format
 


### PR DESCRIPTION
…bestaudio)

without these changes, youtube-dlc is downloading the default format (which is bestaudio+bestvideo) even if the user only wanted the audio part.
bestaudio is converted to whatever audio-format was selected.
Afterwards bestaudio and bestvideo downloads get remomeved.

So downloading bestvideo was pointless, as it was never used anywhere..